### PR TITLE
Split Nav channel into two seperate lables

### DIFF
--- a/sloth/robosub_config.py
+++ b/sloth/robosub_config.py
@@ -90,12 +90,22 @@ LABELS = (
     {
         'attributes': {
             'type':       'rect',
-            'class':      'navigation_channel',
+            'class':      'nav_channel_post',
         },
         'item':     'items.items.LabeledRectItem',
         'inserter': 'sloth.items.RectItemInserter',
-        'hotkey':   'v',
-        'text':     'Navigation Channel'
+        'hotkey':   'z',
+        'text':     'Navigation Channel Post'
+    },
+    {
+        'attributes': {
+            'type':       'rect',
+            'class':      'nav_channel_bar',
+        },
+        'item':     'items.items.LabeledRectItem',
+        'inserter': 'sloth.items.RectItemInserter',
+        'hotkey':   'x',
+        'text':     'Navigation Channel Bar'
     },
     {
         'attributes': {


### PR DESCRIPTION
Navigation channel was split into two labels: nav channel post and nav channel bar. 
Changed shortcuts:
 z - Post;
 x - Bar.