### PR TITLE
Changed roulette name and hotkey.

### DIFF
--- a/sloth/robosub_config.py
+++ b/sloth/robosub_config.py
@@ -131,12 +131,12 @@ LABELS = (
     {
         'attributes': {
             'type':       'roulette',
-            'class':      'roulette_sector',
+            'class':      'roulette',
         },
         'item':     'items.items.LabeledRectItem',
         'inserter': 'sloth.items.RectItemInserter',
-        'hotkey':   'g',
-        'text':     'roulette green sector'
+        'hotkey':   'w',
+        'text':     'roulette wheel'
     },
 )
 


### PR DESCRIPTION
- Changed roulette label name from sector to wheel.

- Changed hotkey for roulette from `g` to `w`