### PR TITLE
Moved OpenCV to optional dependency.

### DIFF
--- a/rslabel_package/rslabel/marker.py
+++ b/rslabel_package/rslabel/marker.py
@@ -8,7 +8,16 @@
 
 from __future__ import print_function
 
-import cv2
+enabled = True
+
+try:
+    import cv2
+except:
+    print('Failed to import OpenCV2. Marker command disabled.')
+    print('Please install OpenCV2 manually to enable data validation.')
+    print(' - pip install opencv-python')
+    enabled = False
+
 import json
 import logging
 import operator
@@ -150,6 +159,11 @@ def app(args):
     Args:
         args: Provided by argparse command line arguments.
     """
+    if not enabled:
+        print('marker command disabled. Please install opencv-python')
+        print(' - pip install opencv-python')
+        return
+
     # Load an optionally provided configuration file.
     global annotation_config
     if args.config is not None:

--- a/rslabel_package/rslabel/upload.py
+++ b/rslabel_package/rslabel/upload.py
@@ -10,21 +10,27 @@ from __future__ import print_function
 
 enabled = True
 
-import cv2
 import glob
 import json
 import os
 import progressbar
 import pysftp
+import shutil
+import tarfile
+import tempfile
+
+try:
+    import cv2
+except:
+    print('OpenCV installation not detected. Upload command disabled.')
+    enabled = False
+
 try:
     import rosbag
     import cv_bridge
 except:
     print('ROS installation not detected. Upload command disabled')
     enabled = False
-import shutil
-import tarfile
-import tempfile
 
 try:
     input = raw_input
@@ -70,8 +76,8 @@ def app(args):
               denotes how many images should be put into each archive.
     """
     if not enabled:
-        print('The upload command is not enabled because ROS is not properly ')
-        print('installed on the host system.')
+        print('The upload command is not enabled because ROS or OpenCV is not'
+        print('properly installed on the host system.')
         return
 
     password = os.environ.get('ROBOSUB_SFTP_PASSWORD')

--- a/rslabel_package/rslabel/upload.py
+++ b/rslabel_package/rslabel/upload.py
@@ -76,7 +76,7 @@ def app(args):
               denotes how many images should be put into each archive.
     """
     if not enabled:
-        print('The upload command is not enabled because ROS or OpenCV is not'
+        print('The upload command is not enabled because ROS or OpenCV is not')
         print('properly installed on the host system.')
         return
 

--- a/rslabel_package/setup.py
+++ b/rslabel_package/setup.py
@@ -7,7 +7,7 @@ setup(
     name="rslabel",
 
     # Version number:
-    version="0.5.2",
+    version="0.5.3",
 
     # Application author details:
     author="Ryan Summers",

--- a/rslabel_package/setup.py
+++ b/rslabel_package/setup.py
@@ -7,7 +7,7 @@ setup(
     name="rslabel",
 
     # Version number:
-    version="0.5.1",
+    version="0.5.2",
 
     # Application author details:
     author="Ryan Summers",
@@ -31,6 +31,5 @@ setup(
     install_requires=[
         "pysftp",
         "progressbar2",
-        "opencv-python",
     ],
 )


### PR DESCRIPTION
Now, individuals can install the rslabel package without having OpenCV installed on the host system. This was implemented because the opencv-python package is a 3GB installation on Windows. Users may optionally install it - if they do, the `mark` command will be enabled for them. Otherwise, the command will be unavailable.