### PR TITLE
Stat Tracking Update

### DIFF
--- a/rslabel_package/CHANGES.txt
+++ b/rslabel_package/CHANGES.txt
@@ -1,0 +1,1 @@
+0.6.0: Added in `stats` command for stat tracking.

--- a/rslabel_package/bin/rslabel
+++ b/rslabel_package/bin/rslabel
@@ -13,6 +13,7 @@ from rslabel import get
 from rslabel import marker
 from rslabel import ret
 from rslabel import show
+from rslabel import stats
 from rslabel import upload
 
 
@@ -49,6 +50,9 @@ if __name__ == '__main__':
     mark_parser.add_argument('--beginning', action='store_true', help='Start at the beginning of the images.')
     mark_parser.add_argument('--scale', type=float, help='Specifies image sizing.', default=1.0)
     mark_parser.set_defaults(func=marker.app)
+
+    stats_parser = sub_parsers.add_parser('stats', description='Get stats on user labeling.')
+    stats_parser.set_defaults(func=stats.app)
 
     args = parser.parse_args()
 

--- a/rslabel_package/rslabel/ret.py
+++ b/rslabel_package/rslabel/ret.py
@@ -8,11 +8,13 @@
 
 from __future__ import print_function
 
+import datetime
 import json
 import os
 import pysftp
 import shutil
 import sys
+import tempfile
 
 try:
     input = raw_input
@@ -27,6 +29,15 @@ def app(args):
         args: Passed in from argparse. Must have a named member `annotations`
               that specifies the path to the annotation JSON.
     """
+
+    # Grab the username for data ownership and the SFTP password.
+    data_owner = os.environ.get('ROBOSUB_WHO_AM_I')
+    if data_owner is None:
+        print('To suppress this prompt, please set the environment variable ',
+                end='')
+        print('ROBOSUB_WHO_AM_I to your name.')
+        data_owner = input('Please enter your name (First Last): ')
+
     password = os.environ.get('ROBOSUB_SFTP_PASSWORD')
     if password is None:
         print('To suppress this prompt, please set the ROBOSUB_SFTP_PASSWORD ',
@@ -113,6 +124,61 @@ def app(args):
             print('robosub.eecs.wsu.edu:/data/vision/labeling/' + src_dir)
             sys.exit(-1)
 
+        # If the annotations already exist on the server, pull them down to
+        # figure out what new labels were added for stat tracking.
+        previous_annotations = []
+        with sftp.cd(src_dir):
+            if os.path.basename(args.annotations) in sftp.listdir():
+                with tempfile.NamedTemporaryFile() as tempf:
+                    sftp.get(os.path.basename(args.annotations), tempf.name)
+                    with open(tempf.name, 'r') as f:
+                        previous_annotations = json.load(f)
+
+        with open(args.annotations, 'r') as f:
+            new_annotations = json.load(f)
+
+        if len(previous_annotations) and len(new_annotations) != len(previous_annotations):
+            print('Provided annotation file and server annotation file differ.')
+            sys.exit(-1)
+
+        log = {'labels_added': 0,
+               'images_labeled': 0,
+               'labels_validated': 0,
+               'images_validated': 0}
+
+        if len(previous_annotations) == 0:
+            for annotation in new_annotations:
+                if in_validation:
+                    log['images_validated'] += 1
+                    log['labels_validated'] += len(annotation['annotations'])
+                else:
+                    labels_added = len(annotation['annotations'])
+
+                    log['labels_added'] += labels_added
+                    if labels_added > 0:
+                        log['images_labeled'] += 1
+        else:
+            for old, new in zip(previous_annotations, new_annotations):
+                if in_validation:
+                    log['images_validated'] += 1
+                    try:
+                        status = new['status']
+                        try:
+                            old_status = old['status']
+                            if old_status != status:
+                                log['labels_validated'] += len(new['annotations'])
+                                log['images_validated'] += 1
+                        except:
+                            log['labels_validated'] += len(new['annotations'])
+                            log['images_validated'] += 1
+                    except:
+                        pass
+                else:
+                    labels_added = len(new['annotations']) - len(old['annotations'])
+                    if labels_added > 0:
+                        log['labels_added'] += labels_added
+                        log['images_labeled'] += 1
+
         # Upload the JSON to the server.
         with sftp.cd(dest_dir):
             sftp.put(args.annotations)
@@ -141,5 +207,28 @@ def app(args):
             if delete:
                 print('Deleting {}/'.format(directory))
                 shutil.rmtree(directory)
+
+        # Finally, upload the stats to the history folder on the
+        # server for stats tracking.
+        stats = {data_owner: log,
+                 'date-time': datetime.datetime.now().isoformat()}
+
+        # Only upload stats if someone has modified the annotations.
+        if log['images_labeled'] != 0 or log['images_validated'] != 0:
+            with tempfile.NamedTemporaryFile(prefix=data_owner) as tempf:
+                with open(tempf.name, 'w') as f:
+                    json.dump(stats, f)
+
+                with sftp.cd('history'):
+                    log_files = [x for x in sftp.listdir() if x.startswith(data_owner.replace(' ', '_'))]
+                    file_numbers = [int(os.path.splitext(x)[0].split('-')[-1]) for x in log_files]
+                    if len(file_numbers) == 0:
+                        f_number = 0
+                    else:
+                        f_number = max(file_numbers) + 1
+
+                    dst = os.path.basename(tempf.name)
+                    sftp.put(tempf.name)
+                    sftp.rename(dst, '{}-{}.log'.format(data_owner.replace(' ', '_'), f_number))
 
         print('Data has been successfully returned.')

--- a/rslabel_package/rslabel/ret.py
+++ b/rslabel_package/rslabel/ret.py
@@ -210,8 +210,9 @@ def app(args):
 
         # Finally, upload the stats to the history folder on the
         # server for stats tracking.
-        stats = {data_owner: log,
-                 'date-time': datetime.datetime.now().isoformat()}
+        stats = [{'owner': data_owner,
+                  'stats': log,
+                  'date-time': datetime.datetime.now().isoformat()}]
 
         # Only upload stats if someone has modified the annotations.
         if log['images_labeled'] != 0 or log['images_validated'] != 0:

--- a/rslabel_package/rslabel/stats.py
+++ b/rslabel_package/rslabel/stats.py
@@ -1,0 +1,69 @@
+#!/usr/bin/python
+"""
+@author Ryan Summers
+@date 4-4-2018
+
+@brief Gets statistics about labeling progress for all users.
+"""
+
+from __future__ import print_function
+
+import glob
+import json
+import os
+import pysftp
+import shutil
+import tempfile
+
+try:
+    input = raw_input
+except:
+    pass
+
+
+def app(args):
+    """ Main entry point for returning data to the server.
+
+    Arguments
+        args: [Unused]
+
+    """
+    password = os.environ.get('ROBOSUB_SFTP_PASSWORD')
+    if password is None:
+        print('To suppress this prompt, please set the ROBOSUB_SFTP_PASSWORD ',
+                end='')
+        print('environment variable.')
+        password = input('Please enter the Robosub SFTP password: ')
+
+    # Open an SFTP connection with the robosub server.
+    with pysftp.Connection('robosub.eecs.wsu.edu',
+                username='sftp_user',
+                password=password,
+                default_path='/data/vision/labeling') as sftp:
+
+        label_stats = dict()
+        dname = tempfile.mkdtemp()
+        sftp.get_d('history', dname)
+        for fname in glob.glob('{}/*.log'.format(dname)):
+            with open(fname, 'r') as f:
+                data = json.load(f)
+            for entry in data:
+                user = entry['owner']
+                log = entry['stats']
+                if user not in label_stats:
+                    label_stats[user] = log
+                else:
+                    for key in log:
+                        label_stats[user][key] += log[key]
+        shutil.rmtree(dname)
+
+    headings = ['User', 'Images Labeled', 'Labels Added', 'Images Validated', 'Labels Validated']
+    row_format = '{:>20}' * len(headings)
+    print(row_format.format(*headings))
+
+    for user in label_stats:
+        images_labeled = label_stats[user]['images_labeled']
+        labels_added = label_stats[user]['labels_added']
+        images_validated = label_stats[user]['images_validated']
+        labels_validated = label_stats[user]['labels_validated']
+        print(row_format.format(user, images_labeled, labels_added, images_validated, labels_validated))

--- a/rslabel_package/setup.py
+++ b/rslabel_package/setup.py
@@ -7,7 +7,7 @@ setup(
     name="rslabel",
 
     # Version number:
-    version="0.5.1",
+    version="0.6.0",
 
     # Application author details:
     author="Ryan Summers",


### PR DESCRIPTION
This modifies the rslabel package to track how many images and labels users have both added and verified. It creates individual log files in the `history/`directory of robosub.eecs.wsu.edu/data/vision/labeling whenever an individual uses the `rslabel return <file>` command with changes. It will also function if the log files are merged into singular log files as well, as logs are stored in plain-text JSON arrays, which will be useful for solidifying logs if they become too verbose. 