### PR TITLE
Clarification step

### DIFF
--- a/rslabel_package/bin/rslabel
+++ b/rslabel_package/bin/rslabel
@@ -33,6 +33,7 @@ if __name__ == '__main__':
 
     get_parser = sub_parsers.add_parser('get', description='Get a dataset for labeling or validation.')
     get_parser.add_argument('--validation', action='store_true', help='Denotes that data should be grabbed for validation instead of labeling.')
+    get_parser.add_argument('--clarification', action='store_true', help='Denotes that data should be grabbed for clarification instead of labeling.')
     get_parser.set_defaults(func=get.app)
 
     show_parser = sub_parsers.add_parser('show', description='Get stats about the image dataset including number of each label type and data sets currently in the processing pipeline.')

--- a/rslabel_package/bin/rslabel
+++ b/rslabel_package/bin/rslabel
@@ -8,13 +8,13 @@
 
 import argparse
 
-from rslabel import collect
-from rslabel import get
-from rslabel import marker
-from rslabel import ret
-from rslabel import show
-from rslabel import stats
-from rslabel import upload
+import collect
+import get
+import marker
+import ret
+import show
+import stats
+import upload
 
 
 if __name__ == '__main__':

--- a/rslabel_package/bin/rslabel
+++ b/rslabel_package/bin/rslabel
@@ -8,13 +8,13 @@
 
 import argparse
 
-import collect
-import get
-import marker
-import ret
-import show
-import stats
-import upload
+from rslabel import collect
+from rslabel import get
+from rslabel import marker
+from rslabel import ret
+from rslabel import show
+from rslabel import stats
+from rslabel import upload
 
 
 if __name__ == '__main__':

--- a/rslabel_package/rslabel/delete.py
+++ b/rslabel_package/rslabel/delete.py
@@ -2,20 +2,19 @@
 # This script is designed to remove bad images given tar name and json file to be present
 
 import argparse
-import datetime
 import json
 import os
 import pysftp
-import shutil
 import sys
 import tempfile
 import glob
 import tarfile
 
-
 # Main function
 def app(args):
     base_name = os.path.splitext(os.path.basename(args.tarname))[0]
+    os.rename(args.tarname, base_name + "-delete.json")
+    os.remove(base_name + ".json")
 
     # Extract tar
     with tarfile.TarFile(args.tarname) as tf:

--- a/rslabel_package/rslabel/delete.py
+++ b/rslabel_package/rslabel/delete.py
@@ -5,24 +5,30 @@ import argparse
 import json
 import os
 import sys
-import tempfile
+import shutil
 import glob
 import tarfile
 
 # Main function
 def app(args):
+    if args.remote:
+        path = "/data/vision/labeling/in_progress/clarification/temp/"
+    else:
+        path = ""
     base_name = os.path.splitext(os.path.basename(args.tarname))[0]
-    print("Working on {}".format(base_name))
-    os.rename(base_name + ".json", base_name + "-delete.json")
-    os.remove(base_name + ".json")
+    print("Working on {}".format(args.tarname))
+    os.rename(path + base_name + ".json",path + base_name + "-delete.json")
 
     # Extract tar
     print("Extracting")
-    with tarfile.TarFile(args.tarname) as tf:
-        tf.extractall()
-    os.remove(args.tarname)
-
-    with open(base_name + '-delete.json', 'r') as f:
+    with tarfile.TarFile(path + args.tarname) as tf:
+        tf.extractall(path)
+    os.remove(path + args.tarname)
+    try:
+        os.remove("{}/{}".format(path + base_name, base_name + ".json"))
+    except:
+        pass
+    with open(path + base_name + '-delete.json', 'r') as f:
         json_contents = json.load(f)
 
     # Looping over to see if there are bad images, and see if the tar is complete
@@ -31,29 +37,31 @@ def app(args):
             ann = annotation['status']
             if ann == 'Bad':
                 print("Removing {}".format(annotation['filename']))
-                os.remove("{}/{}".format(base_name, annotation['filename']))
+                os.remove("{}/{}".format(path + base_name, annotation['filename']))
         except:
             pass
     annotations = []
     print("Creating new json")
-    for f in sorted(glob.glob('{}/*.jpg'.format(base_name))):
+    for f in sorted(glob.glob('{}/*.jpg'.format(path + base_name))):
         annotations.append({'annotations': [],
                             'class': 'image',
                             'filename': os.path.basename(f),
                             'unlabeled': True})
-    os.remove(base_name + '-delete.json')
-    with open("{}/{}".format(base_name, base_name + '.json'), 'w') as f:
+    os.remove(path + base_name + '-delete.json')
+    with open("{}/{}".format(path + base_name, base_name + '.json'), 'w') as f:
         json.dump(annotations, f, indent=4)
     print("Putting everything back into tar")
-    with tarfile.open(base_name + '.tar', "w") as tar:
-        tar.add(base_name)
+    with tarfile.open(path + base_name + '.tar', "w") as tar:
+        tar.add(path + base_name, arcname=base_name)
+    shutil.rmtree(path + base_name)
     print("Putting tar up for labeling")
-    os.rename(base_name + '.tar', "../../new/{}".format(base_name + '.tar'))
+    os.rename(path + base_name + '.tar', "/data/vision/labeling/new/{}".format(base_name + '.tar'))
     print("Done!")
 if __name__ == '__main__':
     # Arguement handler
     parser = argparse.ArgumentParser(description='Utility for deleting bad images.')
     parser.add_argument('tarname', type=str, help='Name of the tar with bad images')
+    parser.add_argument('--remote', action='store_true', help='To run remotely by other script')
     parser.set_defaults(func=app)
     args = parser.parse_args()
     args.func(args)

--- a/rslabel_package/rslabel/delete.py
+++ b/rslabel_package/rslabel/delete.py
@@ -1,10 +1,8 @@
 #!/usr/bin/python
 # This script is designed to remove bad images given tar name and json file to be present
 
-import argparse
 import json
 import os
-import pysftp
 import sys
 import tempfile
 import glob

--- a/rslabel_package/rslabel/delete.py
+++ b/rslabel_package/rslabel/delete.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 # This script is designed to remove bad images given tar name and json file to be present
 
+import argparse
 import json
 import os
 import sys
@@ -11,10 +12,12 @@ import tarfile
 # Main function
 def app(args):
     base_name = os.path.splitext(os.path.basename(args.tarname))[0]
-    os.rename(args.tarname, base_name + "-delete.json")
+    print("Working on {}".format(base_name))
+    os.rename(base_name + ".json", base_name + "-delete.json")
     os.remove(base_name + ".json")
 
     # Extract tar
+    print("Extracting")
     with tarfile.TarFile(args.tarname) as tf:
         tf.extractall()
     os.remove(args.tarname)
@@ -27,10 +30,12 @@ def app(args):
         try:
             ann = annotation['status']
             if ann == 'Bad':
+                print("Removing {}".format(annotation['filename']))
                 os.remove("{}/{}".format(base_name, annotation['filename']))
         except:
             pass
     annotations = []
+    print("Creating new json")
     for f in sorted(glob.glob('{}/*.jpg'.format(base_name))):
         annotations.append({'annotations': [],
                             'class': 'image',
@@ -39,11 +44,12 @@ def app(args):
     os.remove(base_name + '-delete.json')
     with open("{}/{}".format(base_name, base_name + '.json'), 'w') as f:
         json.dump(annotations, f, indent=4)
+    print("Putting everything back into tar")
     with tarfile.open(base_name + '.tar', "w") as tar:
         tar.add(base_name)
-
+    print("Putting tar up for labeling")
     os.rename(base_name + '.tar', "../../new/{}".format(base_name + '.tar'))
-
+    print("Done!")
 if __name__ == '__main__':
     # Arguement handler
     parser = argparse.ArgumentParser(description='Utility for deleting bad images.')

--- a/rslabel_package/rslabel/delete.py
+++ b/rslabel_package/rslabel/delete.py
@@ -1,0 +1,56 @@
+#!/usr/bin/python
+# This script is designed to remove bad images given tar name and json file to be present
+
+import argparse
+import datetime
+import json
+import os
+import pysftp
+import shutil
+import sys
+import tempfile
+import glob
+import tarfile
+
+
+# Main function
+def app(args):
+    base_name = os.path.splitext(os.path.basename(args.tarname))[0]
+
+    # Extract tar
+    with tarfile.TarFile(args.tarname) as tf:
+        tf.extractall()
+    os.remove(args.tarname)
+
+    with open(base_name + '-delete.json', 'r') as f:
+        json_contents = json.load(f)
+
+    # Looping over to see if there are bad images, and see if the tar is complete
+    for annotation in json_contents:
+        try:
+            ann = annotation['status']
+            if ann == 'Bad':
+                os.remove("{}/{}".format(base_name, annotation['filename']))
+        except:
+            pass
+    annotations = []
+    for f in sorted(glob.glob('{}/*.jpg'.format(base_name))):
+        annotations.append({'annotations': [],
+                            'class': 'image',
+                            'filename': os.path.basename(f),
+                            'unlabeled': True})
+    os.remove(base_name + '-delete.json')
+    with open("{}/{}".format(base_name, base_name + '.json'), 'w') as f:
+        json.dump(annotations, f, indent=4)
+    with tarfile.open(base_name + '.tar', "w") as tar:
+        tar.add(base_name)
+
+    os.rename(base_name + '.tar', "../../new/{}".format(base_name + '.tar'))
+
+if __name__ == '__main__':
+    # Arguement handler
+    parser = argparse.ArgumentParser(description='Utility for deleting bad images.')
+    parser.add_argument('tarname', type=str, help='Name of the tar with bad images')
+    parser.set_defaults(func=app)
+    args = parser.parse_args()
+    args.func(args)

--- a/rslabel_package/rslabel/get.py
+++ b/rslabel_package/rslabel/get.py
@@ -71,6 +71,7 @@ def app(args):
             sys.exit(0)
 
         tar = str(tars[0])
+        tar_name = os.path.splitext(tar)[0]
 
         print('Grabbing {}'.format(tar))
 
@@ -123,7 +124,7 @@ def app(args):
                 # available on the server.
                 print('Generating JSON for the dataset.')
                 annotations = []
-                for f in sorted(glob.glob('{}/*.jpg'.format(tar_base))):
+                for f in sorted(glob.glob('{}/*.jpg'.format(tar_name))):
                     annotations.append({'annotations': [],
                                         'class': 'image',
                                         'filename': os.path.basename(f),

--- a/rslabel_package/rslabel/get.py
+++ b/rslabel_package/rslabel/get.py
@@ -74,8 +74,6 @@ def app(args):
 
         print('Grabbing {}'.format(tar))
 
-        tar_name = os.path.splitext(tar)[0]
-
         # Move tar to in_progress - This prevents other users from working on
         # the same data as us.
         sftp.rename(src_dir + tar, dest_dir + tar)
@@ -125,7 +123,7 @@ def app(args):
                 # available on the server.
                 print('Generating JSON for the dataset.')
                 annotations = []
-                for f in sorted(glob.glob('{}/*.jpg'.format(tar_name))):
+                for f in sorted(glob.glob('{}/*.jpg'.format(tar_base))):
                     annotations.append({'annotations': [],
                                         'class': 'image',
                                         'filename': os.path.basename(f),

--- a/rslabel_package/rslabel/get.py
+++ b/rslabel_package/rslabel/get.py
@@ -35,6 +35,9 @@ def app(args):
     if args.validation:
         src_dir = 'unvalidated/'
         dest_dir = 'in_progress/validation/'
+    elif args.clarification:
+        src_dir = 'clarification/'
+        dest_dir = 'in_progress/clarification/'
     else:
         src_dir = 'new/'
         dest_dir = 'in_progress/labeling/'

--- a/rslabel_package/rslabel/ret.py
+++ b/rslabel_package/rslabel/ret.py
@@ -106,14 +106,12 @@ def app(args):
             delete = False
             for annotation in json_contents:
                 try:
-                    status = annotation['status']
-                    if status == 'bad':
-                        os.remove(annotation['filename'])
+                    if annotation['status'] == 'bad':
+                        os.remove(os.path.basename(annotation['filename']))
                         delete = True
                 except:
                     pass
             if delete:
-                os.remove(tar_name)
                 annotations = []
                 tar_base = os.path.splitext(tar_name)[0]
                 json_name = tar_base + '.json'
@@ -127,6 +125,8 @@ def app(args):
                     json.dump(annotations, f, indent=4)
                 with tarfile.open(tar_base, "w") as tar:
                     tar.add(tar_base, arcname=tar_name)
+                    for f in sorted(glob.glob('{}/*.jpg'.format(tar_base))):
+                        tar.add(f, arcname=tar_name)
             src_dir = 'in_progress/clarification'
             dest_dir = 'in_progress/new'
         else:
@@ -224,7 +224,7 @@ def app(args):
             sftp.rename('{}/{}'.format(src_dir, tar_name),
                         '{}/{}'.format(dest_dir, tar_name))
         else:
-            sftp.remove('{}/{}'.format(src_dir, tar_name)
+            sftp.remove('{}/{}'.format(src_dir, tar_name))
 
         # Remove the ownership and annotation files.
         with sftp.cd(src_dir):

--- a/rslabel_package/rslabel/ret.py
+++ b/rslabel_package/rslabel/ret.py
@@ -229,6 +229,7 @@ def app(args):
         else:
             with sftp.cd(dest_dir):
                 sftp.put(tar_name)
+        os.remove(tar_name)
 
         # Move the tar from in_progress to the proper destination.
         # or delete tar if images were bad in clarification

--- a/rslabel_package/rslabel/ret.py
+++ b/rslabel_package/rslabel/ret.py
@@ -225,7 +225,7 @@ def app(args):
 
         if delete and complete:
             with sftp.cd(dest_dir):
-                sftp.execute("delete.py")
+                sftp.execute("delete.py {}".format(tar_name))
         # Remove the ownership and annotation files.
         with sftp.cd(src_dir):
             if os.path.basename(args.annotations) in sftp.listdir():

--- a/rslabel_package/rslabel/ret.py
+++ b/rslabel_package/rslabel/ret.py
@@ -215,8 +215,9 @@ def app(args):
 
         # Upload the JSON to the server. Or tar if the images were bad
         # in clarification proccess
-        with sftp.cd(dest_dir):
-            sftp.put(args.annotations)
+        if delete or (tar_name not in clarification_tars):
+            with sftp.cd(dest_dir):
+                sftp.put(args.annotations)
 
         # Move the tar from in_progress to the proper destination.
         # or delete tar if images were bad in clarification

--- a/rslabel_package/rslabel/ret.py
+++ b/rslabel_package/rslabel/ret.py
@@ -52,6 +52,7 @@ def app(args):
     with open(args.annotations, 'r') as f:
         json_contents = json.load(f)
     tar_name = os.path.splitext(os.path.basename(args.annotations))[0] + '.tar'
+
     # Open an SFTP connection with the robosub server.
     with pysftp.Connection('robosub.eecs.wsu.edu',
                 username='sftp_user',
@@ -74,7 +75,7 @@ def app(args):
         delete = False
 
         # If the dataset is currently being labeled, set up the proper source
-        # and destination paths on the server. If labeling or validation or
+        # and destination paths on the server. If labeling, validation or
         # clarification is not fully completed, move from in_progress back
         # into the intermediate step.
         if tar_name in labeling_tars:
@@ -91,8 +92,8 @@ def app(args):
             src_dir = 'in_progress/labeling/'
             dest_dir = 'unvalidated/' if complete else 'new/'
         elif tar_name in validation_tars:
-            in_validation = True
 
+            in_validation = True
             complete = True
             for annotation in json_contents:
                 try:
@@ -103,9 +104,9 @@ def app(args):
             src_dir = 'in_progress/validation/'
             dest_dir = 'done/' if complete else 'unvalidated/'
         elif tar_name in clarification_tars:
+
             in_clarification = True
             complete = True
-
             dir_name = os.path.dirname(args.annotations)
 
             # Looping over to see if there are bad images, and see if the tar is complete
@@ -127,7 +128,7 @@ def app(args):
         else:
             print('The supplied JSON name does not match any in-progress ',
                     end='')
-            print('validation or labeling sessions or clarification.')
+            print('validation, labeling sessions or clarification.')
             print('Current labeling sessions: {}'.format(labeling_tars))
             print('Current validation sessions: {}'.format(validation_tars))
             print('Current clarification sessions: {}'.format(clarification_tars))

--- a/rslabel_package/rslabel/ret.py
+++ b/rslabel_package/rslabel/ret.py
@@ -52,7 +52,6 @@ def app(args):
     with open(args.annotations, 'r') as f:
         json_contents = json.load(f)
     tar_name = os.path.splitext(os.path.basename(args.annotations))[0] + '.tar'
-
     # Open an SFTP connection with the robosub server.
     with pysftp.Connection('robosub.eecs.wsu.edu',
                 username='sftp_user',
@@ -75,7 +74,7 @@ def app(args):
         delete = False
 
         # If the dataset is currently being labeled, set up the proper source
-        # and destination paths on the server. If labeling, validation or
+        # and destination paths on the server. If labeling or validation or
         # clarification is not fully completed, move from in_progress back
         # into the intermediate step.
         if tar_name in labeling_tars:
@@ -128,7 +127,7 @@ def app(args):
         else:
             print('The supplied JSON name does not match any in-progress ',
                     end='')
-            print('validation, labeling or clarification sessions.')
+            print('validation or labeling sessions or clarification.')
             print('Current labeling sessions: {}'.format(labeling_tars))
             print('Current validation sessions: {}'.format(validation_tars))
             print('Current clarification sessions: {}'.format(clarification_tars))

--- a/rslabel_package/rslabel/ret.py
+++ b/rslabel_package/rslabel/ret.py
@@ -225,7 +225,7 @@ def app(args):
 
         if delete and complete:
             with sftp.cd(dest_dir):
-                sftp.execute("delete.py {}".format(tar_name))
+                sftp.execute("python /data/vision/labeling/in_progress/clarification/temp/delete.py {} --remote".format(tar_name))
         # Remove the ownership and annotation files.
         with sftp.cd(src_dir):
             if os.path.basename(args.annotations) in sftp.listdir():

--- a/rslabel_package/rslabel/show.py
+++ b/rslabel_package/rslabel/show.py
@@ -89,6 +89,9 @@ def app(args):
         with sftp.cd('in_progress/validation/'):
             current_validation_tars = [x for x in sftp.listdir() if x.endswith('.tar')]
 
+        with sftp.cd('in_progress/clarification/'):
+            current_clarification_tars = [x for x in sftp.listdir() if x.endswith('.tar')]
+
         with sftp.cd('new/'):
             new_tars = [x for x in sftp.listdir() if x.endswith('.tar')]
 
@@ -99,10 +102,15 @@ def app(args):
             done_tars = [x for x in sftp.listdir() if x.endswith('.tar')]
             done_dict = get_json_stats(sftp)
 
+        with sftp.cd('clarification/'):
+            clarified_tars = [x for x in sftp.listdir() if x.endswith('.tar')]
+
         print('Image sets waiting to be labeled: {}'.format(len(new_tars)))
         print('Image sets waiting to be validated: {}'.format(len(unvalidated_tars)))
+        print('Image sets waiting to be clarified: {}'.format(len(clarified_tars)))
         print('Image sets being validated: {}'.format(len(current_validation_tars)))
         print('Image sets being labeled: {}'.format(len(current_labeling_tars)))
+        print('Image sets being clarified: {}'.format(len(current_clarification_tars)))
         print('')
         print('Done dataset stats:')
         print('Label\tNumber\tCorrect')

--- a/rslabel_package/rslabel/upload.py
+++ b/rslabel_package/rslabel/upload.py
@@ -139,7 +139,7 @@ def app(args):
     with pysftp.Connection('robosub.eecs.wsu.edu',
             username='sftp_user',
             password=password,
-            default_path='/data/vision/labeling/clarity') as sftp:
+            default_path='/data/vision/labeling/clarification') as sftp:
         for i, f in enumerate(files):
             bar_tar.update(i)
             sftp.put(f)

--- a/rslabel_package/rslabel/upload.py
+++ b/rslabel_package/rslabel/upload.py
@@ -139,7 +139,7 @@ def app(args):
     with pysftp.Connection('robosub.eecs.wsu.edu',
             username='sftp_user',
             password=password,
-            default_path='/data/vision/labeling/new') as sftp:
+            default_path='/data/vision/labeling/clarity') as sftp:
         for i, f in enumerate(files):
             bar_tar.update(i)
             sftp.put(f)

--- a/rslabel_package/setup.py
+++ b/rslabel_package/setup.py
@@ -7,7 +7,7 @@ setup(
     name="rslabel",
 
     # Version number:
-    version="0.6.0",
+    version="0.7.0",
 
     # Application author details:
     author="Ryan Summers",


### PR DESCRIPTION
Basically the idea is that images needs to be pre-validated before they are put out for labeling. The reason why is to look over uploaded data, and delete any images that are "bad"(too blurry, one of the objects is not recognizable or anything that can be in this category). This way whoever labels shouldn't know or worry about if image is good enough to be labeled.

So this PR changes where images are being labeled, and adds functionality to process them before putting them for labeling. Essentially it will work like this:

1. Bags are split and uploaded to `clarification` folder

2.  People who are responsible for validation download batch for clarification using new flag for `rslabel get`

3. Using `rslabel mark` people label which images needs to be deleted

4. Using `rslabel return` people will return clean tar to the server, which put it up for labeling.

5. Continue labeling and validation process as it is now.

Changes:

-  `rslabel get` now has `--clarification` flag to get you bags for clarification.

- `rslabel show` now shows stats for clarification 

-  `rslabel return` now checks if tar is in clarification, marks bad images for deletion in json file. Uploads json with bad images into `in_progress/clarification/temp/`. Then it calls script that is inside of *temp* folder called `delete.py`. If tar does not contain bad images it will just be moved on the server up for labeling.

- `delete.py` It is a source code for the tool that deletes images that are marked as bad, it can work both locally and used by *rslabel return*. It will untar tar, scan json and delete bad images, deleting oroginal tar and json, then create new json for remaining images and tar them all together, and move them to `/new` folder for labeling.

- `rslabel upload` upload folder changed from `new` to `clarification`