### PR TITLE
Rslabel show efficiency upgrade

### DIFF
--- a/rslabel_package/rslabel/count.py
+++ b/rslabel_package/rslabel/count.py
@@ -1,0 +1,42 @@
+#!/usr/bin/python
+# To count stats for data and store it
+
+import json
+import os
+import shutil
+import sys
+import tempfile
+
+def main():
+
+    jsons = [x for x in os.listdir('..') if x.endswith('json')]
+
+    output_dictionary = dict()
+
+    print("Starting scanning.")
+    for f in jsons:
+
+        with open('{}/{}'.format('..', f), 'r') as f:
+            images = json.load(f)
+
+        for image in images:
+            if 'annotations' not in image:
+                continue
+
+            # Count the annotations (total and correct) marked for each image.
+            for annotation in image['annotations']:
+                label_type = annotation['class']
+                if label_type not in output_dictionary:
+                    output_dictionary[label_type] = {'count': 0,
+                                                     'good': 0}
+
+                output_dictionary[label_type]['count'] += 1
+                if 'status' in image and image['status'] == 'Good':
+                    output_dictionary[label_type]['good'] += 1
+
+    with open("count.json", 'w') as m:
+        json.dump(output_dictionary, m, indent=4)
+    print("\nDone.")
+
+if __name__ == '__main__':
+    main()

--- a/rslabel_package/rslabel/count.py
+++ b/rslabel_package/rslabel/count.py
@@ -9,14 +9,14 @@ import tempfile
 
 def main():
 
-    jsons = [x for x in os.listdir('..') if x.endswith('json')]
+    jsons = [x for x in os.listdir('/data/vision/labeling/done/') if x.endswith('json')]
 
     output_dictionary = dict()
 
     print("Starting scanning.")
     for f in jsons:
 
-        with open('{}/{}'.format('..', f), 'r') as f:
+        with open('{}/{}'.format('/data/vision/labeling/done', f), 'r') as f:
             images = json.load(f)
 
         for image in images:
@@ -34,7 +34,7 @@ def main():
                 if 'status' in image and image['status'] == 'Good':
                     output_dictionary[label_type]['good'] += 1
 
-    with open("count.json", 'w') as m:
+    with open("/data/vision/labeling/done/count/count.json", 'w') as m:
         json.dump(output_dictionary, m, indent=4)
     print("\nDone.")
 

--- a/rslabel_package/rslabel/ret.py
+++ b/rslabel_package/rslabel/ret.py
@@ -273,6 +273,6 @@ def app(args):
                         sftp.put(tempf.name)
                         sftp.rename(dst, '{}-{}.log'.format(data_owner.replace(' ', '_'), f_number))
 
-        sftp.execute("python /data/vision/labeling/done/count/count.py") #Update Stats on the server
+        sftp.execute("python /data/vision/labeling/done/count/count.py") # Update Stats on the server
 
         print('Data has been successfully returned.')

--- a/rslabel_package/rslabel/ret.py
+++ b/rslabel_package/rslabel/ret.py
@@ -273,4 +273,6 @@ def app(args):
                         sftp.put(tempf.name)
                         sftp.rename(dst, '{}-{}.log'.format(data_owner.replace(' ', '_'), f_number))
 
+        sftp.execute("python /data/vision/labeling/done/count/count.py") #Update Stats on the server
+
         print('Data has been successfully returned.')

--- a/rslabel_package/rslabel/show.py
+++ b/rslabel_package/rslabel/show.py
@@ -24,39 +24,16 @@ except:
 
 def get_json_stats(sftp):
     """ Collects metadata about the completed datasets. """
-    jsons = [x for x in sftp.listdir() if x.endswith('json')]
 
-    working_directory = tempfile.mkdtemp()
+    print('Grabbing JSON information...')
+    sftp.get("count/count.json")
 
     output_dictionary = dict()
 
-    # Get information about each JSON in the directory.
-    print('Grabbing JSON information...')
-    bar = progressbar.ProgressBar(max_value=len(jsons))
-    for i, f in enumerate(jsons):
-        bar.update(i)
-        sftp.get(f, localpath='{}/{}'.format(working_directory, f))
-        with open('{}/{}'.format(working_directory, f), 'r') as f:
-            images = json.load(f)
+    with open("count.json", 'r') as f:
+        output_dictionary = json.load(f)
 
-        for image in images:
-            if 'annotations' not in image:
-                continue
-
-            # Count the annotations (total and correct) marked for each image.
-            for annotation in image['annotations']:
-                label_type = annotation['class']
-                if label_type not in output_dictionary:
-                    output_dictionary[label_type] = {'count': 0,
-                                                     'good': 0}
-
-                output_dictionary[label_type]['count'] += 1
-                if 'status' in image and image['status'] == 'Good':
-                    output_dictionary[label_type]['good'] += 1
-    bar.finish()
-
-    # Remove the temporary folder where the JSONs were stored.
-    shutil.rmtree(working_directory)
+    os.remove("count.json")
 
     return output_dictionary
 


### PR DESCRIPTION
Briefly - this improves efficiency of `rslabel show`, reduces potential wait time. This is achieved by server storing stats about images labeled/good in a local json file in `done` folder. So every time you upload something using `rslabel return` it will run `count.py` on the server to update the stats. So now `rslabel get` will only have to download temporary one file `count.json` to use it's counted info, making it 3-5 seconds on average no matter how much data we have.

So I have noticed that `rslabel show` takes about 20-22 seconds to show statistics. At first it when we had a bit of data it took 3 seconds, now that we have 100 json files it takes 20-25 seconds. Sometimes it takes more time if there are some connection problems between server and your machine. In theory if we keep using this method and increase data, the wait time will grow linearly to minutes. I have made my research and found the source of this slowdown.

Cause - function that counts how many images were done and how many are actually good has to temporary upload each json file from `done` folder to local machine and count them manually. Now counting doesn't take much as it is mostly O(N) * O(M) (where N is number of json files and M number of annotations), but the download takes time as it has to request sever to download file and wait for it to respond back and download - if server has internet issues or is overloaded with internet queries that can take a while.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palouserobosub/vision_dev/26)
<!-- Reviewable:end -->
