### PR TITLE
Rslabel misc update

### DIFF
--- a/rslabel_package/CHANGES.txt
+++ b/rslabel_package/CHANGES.txt
@@ -2,3 +2,4 @@
 0.7.0: Added clarification step.
 0.8.0: Improved efficiency of `show`
 0.9.0: `get`, `return` and `show` now have download/upload progress bars.
+0.9.1: `ret` now reports number of bad images found, and if they were deleted. Two new shortcuts for `get` as arguments

--- a/rslabel_package/bin/rslabel
+++ b/rslabel_package/bin/rslabel
@@ -32,8 +32,8 @@ if __name__ == '__main__':
     collect_parser.set_defaults(func=collect.app)
 
     get_parser = sub_parsers.add_parser('get', description='Get a dataset for labeling or validation.')
-    get_parser.add_argument('--validation', action='store_true', help='Denotes that data should be grabbed for validation instead of labeling.')
-    get_parser.add_argument('--clarification', action='store_true', help='Denotes that data should be grabbed for clarification instead of labeling.')
+    get_parser.add_argument('--validation', '-V', action='store_true', help='Denotes that data should be grabbed for validation instead of labeling.')
+    get_parser.add_argument('--clarification', '-C', action='store_true', help='Denotes that data should be grabbed for clarification instead of labeling.')
     get_parser.set_defaults(func=get.app)
 
     show_parser = sub_parsers.add_parser('show', description='Get stats about the image dataset including number of each label type and data sets currently in the processing pipeline.')

--- a/rslabel_package/rslabel/ret.py
+++ b/rslabel_package/rslabel/ret.py
@@ -80,6 +80,7 @@ def app(args):
         in_validation = False
         in_clarification = False
         delete = False
+        bad_count = 0
 
         # If the dataset is currently being labeled, set up the proper source
         # and destination paths on the server. If labeling, validation or
@@ -122,6 +123,7 @@ def app(args):
                     ann = annotation['status']
                     if ann == 'Bad':
                         delete = True
+                        bad_count += 1
                 except:
                     complete = False
                     pass
@@ -238,8 +240,10 @@ def app(args):
                     '{}/{}'.format(dest_dir, tar_name))
 
         if delete and complete:
+            print('Found {} bad images. Deleting'.format(bad_count))
             with sftp.cd(dest_dir):
                 sftp.execute("python /data/vision/labeling/in_progress/clarification/temp/delete.py {} --remote".format(tar_name))
+                print('Deleted, taring up remaining images and puting into labeling folder.')
         # Remove the ownership and annotation files.
         with sftp.cd(src_dir):
             if os.path.basename(args.annotations) in sftp.listdir():

--- a/rslabel_package/setup.py
+++ b/rslabel_package/setup.py
@@ -7,7 +7,7 @@ setup(
     name="rslabel",
 
     # Version number:
-    version="0.9.0",
+    version="0.9.1",
 
     # Application author details:
     author="Ryan Summers",


### PR DESCRIPTION
When I was doing data clarification I was too lazy to type `rslabel get --clarification` each time, as mistypo occurs a lot, or even just use arrow keys to run it again takes more time then typing it again. So I added two alternative shortcuts `-C` for clarification and `-V` for validation to save time.

Summary:

- `rslabel get` now has two alternative arguments for clarification and labeling as `-C` and `-V`

- `rslabel return` now reports number of bad images that needs to be deleted, and states if deletion script were run.